### PR TITLE
Add SQL billing rule examples from docs

### DIFF
--- a/sql-billing-rules/add-a-credit.sql
+++ b/sql-billing-rules/add-a-credit.sql
@@ -1,0 +1,4 @@
+-- title: "Add a Credit",
+
+INSERT INTO costs (provider, service, cost_category, cost_sub_category, cost_type, amount)
+VALUES ('aws', 'Billing Credit', 'Billing Credit', 'Billing Credit', 'Credit', -500)

--- a/sql-billing-rules/add-a-monthly-charge.sql
+++ b/sql-billing-rules/add-a-monthly-charge.sql
@@ -1,0 +1,4 @@
+-- title: "Add a Monthly Charge",
+
+INSERT INTO costs (provider, service, cost_category, cost_sub_category, cost_type, amount)
+VALUES ('aws', 'Platform Fee', 'Platform Fee', 'Platform Fee', 'Fee', 1100)

--- a/sql-billing-rules/add-a-processing-fee.sql
+++ b/sql-billing-rules/add-a-processing-fee.sql
@@ -1,0 +1,4 @@
+-- title: "Add a Processing Fee",
+
+INSERT INTO costs (provider, service, cost_category, cost_sub_category, cost_type, amount)
+VALUES ('aws', 'Processing Fee', 'Processing Fee', 'Processing Fee', 'Fee', 3500)

--- a/sql-billing-rules/add-a-support-fee-with-a-specific-date.sql
+++ b/sql-billing-rules/add-a-support-fee-with-a-specific-date.sql
@@ -1,0 +1,4 @@
+-- title: "Add a Support Fee with a Specific Date",
+
+INSERT INTO costs (provider, date, service, cost_category, cost_type, amount)
+VALUES ('aws', '2026-01-31', 'Support Fee', 'Support Fee', 'Fee', 5000)

--- a/sql-billing-rules/apply-5-percent-discount-aws.sql
+++ b/sql-billing-rules/apply-5-percent-discount-aws.sql
@@ -1,0 +1,5 @@
+-- title: "Apply a 5% Discount (AWS)",
+
+UPDATE aws
+SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * 0.95
+WHERE aws.lineItem/LineItemType != 'Credit'

--- a/sql-billing-rules/apply-discount-excluding-reservations-azure.sql
+++ b/sql-billing-rules/apply-discount-excluding-reservations-azure.sql
@@ -1,0 +1,6 @@
+-- title: "Apply Discount Excluding Reservations (Azure)",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 0.95
+WHERE costs.provider = 'azure' 
+AND LOWER(costs.resource_id) NOT LIKE '%/providers/microsoft.capacity/reservationorders%'

--- a/sql-billing-rules/apply-discount-to-nce-licenses-azure-csp.sql
+++ b/sql-billing-rules/apply-discount-to-nce-licenses-azure-csp.sql
@@ -1,0 +1,5 @@
+-- title: "Apply Discount to NCE Licenses (Azure CSP)",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 0.95
+WHERE costs.provider = 'azure_csp' AND costs.service = 'NCE License' AND costs.cost_type = 'Purchase'

--- a/sql-billing-rules/apply-markup-by-azure-subscription.sql
+++ b/sql-billing-rules/apply-markup-by-azure-subscription.sql
@@ -1,0 +1,5 @@
+-- title: "Apply Markup by Azure Subscription",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 1.10
+WHERE costs.provider = 'azure' AND costs.resource_account_id = 'your-subscription-id'

--- a/sql-billing-rules/apply-markup-by-cost-category.sql
+++ b/sql-billing-rules/apply-markup-by-cost-category.sql
@@ -1,0 +1,5 @@
+-- title: "Apply Markup by Cost Category",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 1.10
+WHERE costs.cost_category = 'Storage'

--- a/sql-billing-rules/apply-markup-to-azure-services.sql
+++ b/sql-billing-rules/apply-markup-to-azure-services.sql
@@ -1,0 +1,5 @@
+-- title: "Apply Markup to Azure Services",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 1.10
+WHERE costs.provider = 'azure' AND costs.service = 'Virtual Machines'

--- a/sql-billing-rules/apply-service-specific-markup.sql
+++ b/sql-billing-rules/apply-service-specific-markup.sql
@@ -1,0 +1,5 @@
+-- title: "Apply Service-Specific Markup",
+
+UPDATE costs 
+SET costs.amount = costs.amount * 1.05
+WHERE costs.service IN ('Amazon Relational Database Service', 'AWS Lambda')

--- a/sql-billing-rules/exclude-aws-support-products-aws.sql
+++ b/sql-billing-rules/exclude-aws-support-products-aws.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude AWS Support Products (AWS)",
+
+DELETE FROM aws 
+WHERE aws.lineItem/ProductCode IN ('AWSSupportBusiness', 'AWSSupportEnterprise', 'AWSSupportDeveloper')

--- a/sql-billing-rules/exclude-bundleddiscount-line-items-aws.sql
+++ b/sql-billing-rules/exclude-bundleddiscount-line-items-aws.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude BundledDiscount Line Items (AWS)",
+
+DELETE FROM aws 
+WHERE aws.lineItem/LineItemType = 'BundledDiscount'

--- a/sql-billing-rules/exclude-marketplace-by-billing-entity-aws.sql
+++ b/sql-billing-rules/exclude-marketplace-by-billing-entity-aws.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Marketplace by Billing Entity (AWS)",
+
+DELETE FROM aws 
+WHERE aws.bill/BillingEntity = 'AWS Marketplace'

--- a/sql-billing-rules/exclude-marketplace-costs.sql
+++ b/sql-billing-rules/exclude-marketplace-costs.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Marketplace Costs",
+
+DELETE FROM costs
+WHERE costs.cost_category = 'AWS Marketplace'

--- a/sql-billing-rules/exclude-multiple-spp-discount-types.sql
+++ b/sql-billing-rules/exclude-multiple-spp-discount-types.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Multiple SPP Discount Types",
+
+DELETE FROM costs 
+WHERE costs.cost_type IN ('SppDiscount', 'UnamortizedSppDiscount')

--- a/sql-billing-rules/exclude-other-provider-items.sql
+++ b/sql-billing-rules/exclude-other-provider-items.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Other Provider Items",
+
+DELETE FROM costs 
+WHERE costs.provider = 'temporal' AND costs.service = 'Temporal Cloud' AND costs.cost_sub_category = 'Actions'

--- a/sql-billing-rules/exclude-partner-earned-credit-azure-csp.sql
+++ b/sql-billing-rules/exclude-partner-earned-credit-azure-csp.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Partner Earned Credit (Azure CSP)",
+
+DELETE FROM costs 
+WHERE costs.provider = 'azure_csp' AND costs.cost_type = 'PartnerEarnedCredit'

--- a/sql-billing-rules/exclude-reservation-fees-for-specific-accounts.sql
+++ b/sql-billing-rules/exclude-reservation-fees-for-specific-accounts.sql
@@ -1,0 +1,8 @@
+-- title: "Exclude Reservation Fees for Specific Accounts",
+
+DELETE FROM aws
+WHERE aws.lineItem/LineItemType = 'RIFee'
+AND (
+  aws.reservation/ReservationARN LIKE '%:111111111111:%'
+  OR aws.reservation/ReservationARN LIKE '%:222222222222:%'
+)

--- a/sql-billing-rules/exclude-spp-discounts.sql
+++ b/sql-billing-rules/exclude-spp-discounts.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude SPP Discounts",
+
+DELETE FROM costs 
+WHERE costs.cost_type = 'SppDiscount'

--- a/sql-billing-rules/exclude-spp-edp-discount-line-items-aws.sql
+++ b/sql-billing-rules/exclude-spp-edp-discount-line-items-aws.sql
@@ -1,0 +1,8 @@
+-- title: "Exclude SPP/EDP Discount Line Items (AWS)",
+
+DELETE FROM aws
+WHERE aws.lineItem/LineItemType IN ('Discount', 'Credit')
+AND (
+  aws.lineItem/LineItemDescription ILIKE '%Enterprise Discount Program%'
+  OR aws.lineItem/LineItemDescription ILIKE '%Solution Provider%'
+)

--- a/sql-billing-rules/exclude-support-costs.sql
+++ b/sql-billing-rules/exclude-support-costs.sql
@@ -1,0 +1,4 @@
+-- title: "Exclude Support Costs",
+
+DELETE FROM costs 
+WHERE costs.service = 'AWS Support (Business)'

--- a/sql-billing-rules/reduce-costs-for-a-specific-aws-account.sql
+++ b/sql-billing-rules/reduce-costs-for-a-specific-aws-account.sql
@@ -1,0 +1,5 @@
+-- title: "Reduce Costs for a Specific AWS Account",
+
+UPDATE aws 
+SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * 0.50
+WHERE aws.lineItem/UsageAccountId = '111111111111'

--- a/sql-billing-rules/remove-costs-for-specific-aws-accounts.sql
+++ b/sql-billing-rules/remove-costs-for-specific-aws-accounts.sql
@@ -1,0 +1,8 @@
+-- title: "Remove Costs for Specific AWS Accounts",
+
+DELETE FROM aws 
+WHERE aws.lineItem/UsageAccountId IN (
+  '111111111111',
+  '222222222222',
+  '333333333333'
+)

--- a/sql-billing-rules/rename-a-service.sql
+++ b/sql-billing-rules/rename-a-service.sql
@@ -1,0 +1,5 @@
+-- title: "Rename a Service",
+
+UPDATE costs
+SET costs.service = 'Custom Compute'
+WHERE costs.provider = 'aws' AND costs.service = 'Amazon Elastic Compute Cloud - Compute'

--- a/sql-billing-rules/rerate-reserved-instance-costs-to-on-demand-pricing.sql
+++ b/sql-billing-rules/rerate-reserved-instance-costs-to-on-demand-pricing.sql
@@ -1,0 +1,9 @@
+-- title: "Rerate Reserved Instance Costs to On-Demand Pricing",
+
+UPDATE aws 
+SET aws.lineItem/UnblendedCost = aws.pricing/publicOnDemandCost, aws.lineItem/UnblendedRate = aws.pricing/publicOnDemandRate
+WHERE aws.lineItem/LineItemType = 'DiscountedUsage'
+AND (
+  aws.reservation/ReservationARN LIKE '%111111111111%'
+  OR aws.reservation/ReservationARN LIKE '%222222222222%'
+)

--- a/sql-billing-rules/set-credits-to-zero.sql
+++ b/sql-billing-rules/set-credits-to-zero.sql
@@ -1,0 +1,5 @@
+-- title: "Set Credits to Zero",
+
+UPDATE costs 
+SET costs.amount = 0
+WHERE costs.cost_type = 'Credit'

--- a/sql-billing-rules/unamortize-savings-plans-for-a-specific-account.sql
+++ b/sql-billing-rules/unamortize-savings-plans-for-a-specific-account.sql
@@ -1,0 +1,6 @@
+-- title: "Unamortize Savings Plans for a Specific Account",
+
+UPDATE aws 
+SET aws.lineItem/LineItemType = 'Usage', aws.savingsPlan/SavingsPlanARN = NULL
+WHERE aws.lineItem/LineItemType = 'SavingsPlanCoveredUsage'
+AND aws.savingsPlan/SavingsPlanARN LIKE 'arn:aws:savingsplans::111111111111%'

--- a/sql-billing-rules/zero-out-cost-and-rate-for-internal-accounts.sql
+++ b/sql-billing-rules/zero-out-cost-and-rate-for-internal-accounts.sql
@@ -1,0 +1,5 @@
+-- title: "Zero Out Cost and Rate for Internal Accounts",
+
+UPDATE aws 
+SET aws.lineItem/UnblendedCost = '0', aws.lineItem/UnblendedRate = '0'
+WHERE aws.lineItem/UsageAccountId IN ('111111111111', '222222222222', '333333333333')


### PR DESCRIPTION
## Summary
- sync the `sql-billing-rules` examples in FinOps as Code with the current examples documented in `docs/sql_billing_rules.mdx`
- add missing AWS, Azure, Azure CSP, and `INSERT INTO costs` examples as standalone `.sql` files
- preserve the existing older example files rather than replacing or removing them in this PR

## Test plan
- [x] Compared the SQL examples in `docs/sql_billing_rules.mdx` against the existing files in `sql-billing-rules`
- [x] Verified the branch diff only adds new example files
- [x] Confirmed the repo is clean after committing

Made with [Cursor](https://cursor.com)