### PR TITLE
Fix: SQL billing rule examples that mis-bill or fail validation

### DIFF
--- a/sql-billing-rules/discount-unless-credit-fee-enterprisesupport-marketplace.sql
+++ b/sql-billing-rules/discount-unless-credit-fee-enterprisesupport-marketplace.sql
@@ -2,7 +2,7 @@
 
 
 UPDATE aws
-SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * '0.095'
+SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * 0.905
 WHERE 
 aws.lineItem/ProductCode != 'AwsPremiumSupport' 
 AND aws.lineItem/LineItemType != 'Credit' 

--- a/sql-billing-rules/exclude-spp-edp-discount-line-items-aws.sql
+++ b/sql-billing-rules/exclude-spp-edp-discount-line-items-aws.sql
@@ -3,6 +3,6 @@
 DELETE FROM aws
 WHERE aws.lineItem/LineItemType IN ('Discount', 'Credit')
 AND (
-  aws.lineItem/LineItemDescription ILIKE '%Enterprise Discount Program%'
-  OR aws.lineItem/LineItemDescription ILIKE '%Solution Provider%'
+  aws.lineItem/LineItemDescription LIKE '%Enterprise Discount Program%'
+  OR aws.lineItem/LineItemDescription LIKE '%Solution Provider%'
 )

--- a/sql-billing-rules/marketplace-markup.sql
+++ b/sql-billing-rules/marketplace-markup.sql
@@ -1,5 +1,5 @@
 -- title: "+2% on AWS Marketplace",
 
 UPDATE aws
-SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * '1.02'
+SET aws.lineItem/UnblendedCost = aws.lineItem/UnblendedCost * 1.02
 WHERE aws.bill/BillingEntity = 'AWS Marketplace'

--- a/sql-billing-rules/remove-specific-sp-discounts.sql
+++ b/sql-billing-rules/remove-specific-sp-discounts.sql
@@ -1,5 +1,5 @@
--- title: "Remove arn:aws:savingsplans::004284483911:savingsp...",
+-- title: "Remove arn:aws:savingsplans::111111111111:savingsp...",
 
 UPDATE aws
 SET aws.lineItem/LineItemType = 'Usage'
-WHERE aws.lineItem/LineItemType = 'SavingsPlanCoveredUsage' AND aws.savingsPlan/SavingsPlanARN = 'arn:aws:savingsplans::01234567890:savingsplan/abcdefg12345' -- replace with the actual savings plan ARN
+WHERE aws.lineItem/LineItemType = 'SavingsPlanCoveredUsage' AND aws.savingsPlan/SavingsPlanARN = 'arn:aws:savingsplans::111111111111:savingsplan/abcdefg12345' -- replace with the actual savings plan ARN


### PR DESCRIPTION
## Summary
- the "9.5% discount unless Credit, Fee, Enterprise Support or Marketplace Purchase" example multiplies `UnblendedCost` by `'0.095'`, which keeps 9.5% of the cost instead of taking 9.5% off. An MSP copying it as shipped under-bills eligible line items by roughly 10x, and rule validation accepts the rule, so nothing catches the mistake. A 9.5% discount retains 90.5% of cost: `* 0.905`
- `exclude-spp-edp-discount-line-items-aws.sql` cannot be saved at all: the rule editor rejects it with `Query contains disallowed keywords: ILIKE`. Switched to `LIKE`, which matches the same rows since CUR `lineItem/LineItemDescription` values are canonically cased ("Enterprise Discount Program...", "Solution Provider...")
- unquote the two remaining string multipliers (`'0.095'` here and `'1.02'` in `marketplace-markup.sql`) to match the other eight discount and markup examples and every numeric literal in the [SQL Billing Rules docs](https://docs.vantage.sh/sql_billing_rules), like `costs.amount * 0.90`
- standardize `remove-specific-sp-discounts.sql` on the `111111111111` placeholder account id the seven sibling files already use (the old body placeholder had 11 digits, not a valid account id length)

Left out deliberately: the quoted `'0'` in `zero-out-cost-and-rate-for-internal-accounts.sql`, which mirrors the docs example verbatim, and `remove-ri-sp.sql`, which I'd rather verify separately before touching.

## Test plan
- [x] Ran all 35 examples through the same validation path the rule editor runs on save: 35/35 pass (before this PR: 34/35, the ILIKE example failed)
- [x] Applied the corrected discount rule to a sample eligible CUR row: cost 100.0 becomes 90.5. The shipped form validates clean and produces 9.5, the roughly 10x under-billing
- [x] Checked the guard clauses: Credit, Fee, AwsPremiumSupport, and AWS Marketplace rows pass through unchanged