### PR TITLE
Fix: Terraform demos that fail validate, and add CI so they stay fixed

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -1,0 +1,39 @@
+name: Validate Terraform demos
+
+on:
+  pull_request:
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-validate.yml"
+  push:
+    branches: [main]
+    paths:
+      - "terraform/**"
+      - ".github/workflows/terraform-validate.yml"
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.15.8"
+
+      - name: Validate every demo directory
+        run: |
+          set -uo pipefail
+          failed=0
+          for dir in $(find terraform -name '*.tf' -not -path '*/.terraform/*' -exec dirname {} \; | sort -u); do
+            echo "::group::${dir}"
+            if (cd "$dir" && terraform init -backend=false -input=false > /dev/null && terraform validate -no-color); then
+              echo "::endgroup::"
+            else
+              echo "::endgroup::"
+              echo "::error::validation failed in ${dir}"
+              failed=1
+            fi
+          done
+          exit "$failed"

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,10 @@ pyrightconfig.json
 # Local .terraform directories
 **/.terraform/*
 
+# Provider lockfiles from running the demos locally. Real infrastructure should
+# commit these; standalone demo dirs should not, so inits stay disposable.
+**/.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/terraform/aws/aws-data-transfer/provider.tf
+++ b/terraform/aws/aws-data-transfer/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/aws/aws-ipv4/provider.tf
+++ b/terraform/aws/aws-ipv4/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/aws/aws-s3/provider.tf
+++ b/terraform/aws/aws-s3/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/cost-reporting-structure/main.tf
+++ b/terraform/cost-reporting-structure/main.tf
@@ -18,9 +18,9 @@ resource "vantage_cost_report" "team_reports" {
 
 resource "vantage_dashboard" "bu_dashboard" {
   for_each        = local.business_units
-  widget_tokens   = [
+  widgets = [
     for cost_center_key, cost_center_info in local.cost_centers :
-    vantage_cost_report.team_reports[cost_center_key].token
+    { widgetable_token = vantage_cost_report.team_reports[cost_center_key].token }
     if cost_center_info.business_unit == each.value
   ]
   title           = "${each.value} Dashboard"

--- a/terraform/cost-reporting-structure/provider.tf
+++ b/terraform/cost-reporting-structure/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/cost-tags/provider.tf
+++ b/terraform/cost-tags/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/intro-to-finops-as-code/main.tf
+++ b/terraform/intro-to-finops-as-code/main.tf
@@ -17,9 +17,9 @@ module "marketing_snowflake" {
 }
 
 resource "vantage_dashboard" "dashboard" {
-  widget_tokens = [
-    module.marketing_aws.marketing_aws_cost_report_token,
-    module.marketing_snowflake.marketing_snowflake_cost_report_token
+  widgets = [
+    { widgetable_token = module.marketing_aws.marketing_aws_cost_report_token },
+    { widgetable_token = module.marketing_snowflake.marketing_snowflake_cost_report_token }
   ]
   title           = "Marketing Dashboard"
   date_interval   = "last_6_months"

--- a/terraform/intro-to-finops-as-code/provider.tf
+++ b/terraform/intro-to-finops-as-code/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/intro-to-finops-as-code/vantage_modules/provider.tf
+++ b/terraform/intro-to-finops-as-code/vantage_modules/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/intro-to-finops-as-code/variables.tf
+++ b/terraform/intro-to-finops-as-code/variables.tf
@@ -1,5 +1,5 @@
 variable "marketing_workspace_token" {
   description = "Value of Marketing workspace token"
   type        = string
-  default     = "<YOUR_WORKSPACE_TOKEN"
+  default     = "<YOUR_WORKSPACE_TOKEN>"
 }

--- a/terraform/okta/okta-terraform-demo/okta-groups.csv
+++ b/terraform/okta/okta-terraform-demo/okta-groups.csv
@@ -1,4 +1,4 @@
-team
+name
 Finance
 Engineering
 DevOps

--- a/terraform/okta/okta-terraform-demo/proivder.tf
+++ b/terraform/okta/okta-terraform-demo/proivder.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
     okta = {
       source = "okta/okta"

--- a/terraform/segments-structure/provider.tf
+++ b/terraform/segments-structure/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/temporal-costs/provider.tf
+++ b/terraform/temporal-costs/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }

--- a/terraform/virtual-tags-structure/provider.tf
+++ b/terraform/virtual-tags-structure/provider.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     vantage = {
-      source = "vantage-sh/vantage"
+      source  = "vantage-sh/vantage"
+      version = "~> 0.3.15"
     }
   }
 }


### PR DESCRIPTION
## Summary
Cloning the repo today gets you demos that fail `terraform validate` before you change anything:

- `intro-to-finops-as-code` and `cost-reporting-structure` still use `widget_tokens`, removed from the provider schema (`Error: Unsupported argument ... "widget_tokens" is not expected here`). Migrated both dashboards to `widgets = [{ widgetable_token = ... }]` per the [provider docs](https://registry.terraform.io/providers/vantage-sh/vantage/latest/docs/resources/dashboard), and closed the unterminated `<YOUR_WORKSPACE_TOKEN` placeholder
- the okta demo reads `.name` on rows whose CSV header is `team` (`This object does not have an attribute named "name"`). Renamed the column to `name`
- pinned the provider to `~> 0.3.15` in every demo; `widget_tokens` was removed inside the 0.3.x line, so a looser `~> 0.3` would not have helped
- added CI that runs `init` and `validate` over every terraform directory on any PR or push touching `terraform/`; validate alone would have caught all three breakages. Also gitignored `.terraform.lock.hcl`, right to commit for real infrastructure but wrong for demo dirs users init constantly

Left out deliberately: `fmt -check` in CI (untouched demos are not fmt-clean and new CI must be green on its own PR), the misnamed `proivder.tf`, and dashboard-replicator's `widget_tokens` POST.

## Test plan
- [x] Before (Terraform 1.15.8, provider 0.3.15): three demos fail validate with the errors above. After: all 11 terraform dirs pass, using the same discovery loop the workflow runs
- [x] `terraform plan` with placeholder credentials evaluates both dashboard graphs (23 and 7 resources), so the wiring holds beyond the schema
- [x] Diff is config, one workflow, one gitignore rule; no lockfiles or `.terraform` artifacts