### PR TITLE
Fix: python demos that fail as shipped

### DIFF
--- a/python/aws-account-based-virtual-tag/virtual_tag_by_account.py
+++ b/python/aws-account-based-virtual-tag/virtual_tag_by_account.py
@@ -4,10 +4,9 @@ import os
 
 
 url = "https://api.vantage.sh/v2/virtual_tag_configs"
-VANTAGE_ACCESS_TOKEN = os.environ.get("VANTAGE_ACCESS_TOKEN")
+VANTAGE_API_TOKEN = os.environ.get("VANTAGE_API_TOKEN")
 
 session = boto3.session.Session()
-client = session.client('sts')
 org = session.client('organizations')
 
 # get list of accounts
@@ -19,7 +18,7 @@ for page in page_iterator:
     for acct in page['Accounts']:
         accounts.append({
             "filter": f"costs.provider = 'aws' AND costs.account_id = '{acct['Id']}'",
-            "name": acct['Name'].replace("'?!", "")
+            "name": "".join(c for c in acct['Name'] if c not in "'?!")
         })
 
 payload = {
@@ -30,13 +29,9 @@ payload = {
 headers = {
     "accept": "application/json",
     "content-type": "application/json",
-    "authorization": f"Bearer {VANTAGE_ACCESS_TOKEN}"
+    "authorization": f"Bearer {VANTAGE_API_TOKEN}"
 }
 
 response = requests.post(url, json=payload, headers=headers)
+response.raise_for_status()
 print(response.text)
-
-
-
-
-

--- a/python/dashboard-replicator/README.md
+++ b/python/dashboard-replicator/README.md
@@ -15,12 +15,13 @@ This tool is particularly useful for teams using **FinOps-as-Code**, enabling co
 
 - Python 3.7+
 - `requests` library (for Vantage API calls)
+- `simple-term-menu` library (for the interactive terminal menus)
 - Valid Vantage **API tokens** for source and target workspaces
 
 Install dependencies:
 
 ```bash
-pip install requests
+pip install requests simple-term-menu
 ```
 
 ## Setup
@@ -52,7 +53,7 @@ The script will:
 
 ## Notes & Limitations
 
-- This script can only add existing Financial Commitment Reports, as there is not a supported API to create new FCRs
+- Saved Filters attached to Cost Reports are not recreated in the destination workspace; reattach them manually after cloning
 - Tags and linked entities (e.g., saved filters) may require manual verification after cloning.
 - Rate limits on the Vantage API may apply for very large dashboards.
 

--- a/python/dashboard-replicator/vantage_dashboard_replicator.py
+++ b/python/dashboard-replicator/vantage_dashboard_replicator.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import requests
 import json
 import pprint
@@ -12,6 +14,12 @@ def headers(token):
         "accept": "application/json",
         "authorization": f"Bearer {token}"
     }
+
+def widget_payload(new_token: str, source_widget: dict | None) -> dict:
+    """Return a dashboard widget entry, keeping the source widget's settings."""
+    settings = (source_widget or {}).get("settings")
+    payload = {"widgetable_token": new_token}
+    return {**payload, "settings": settings} if settings else payload
 
 def selector_menu(options, title=None):
     """
@@ -105,12 +113,13 @@ def copy_dashboards(source_api_token, destination_api_token):
         og_dashboard_resp = requests.get(f"{url}/dashboards/{dash_token}", headers=headers(source_api_token))
         og_dashboard = og_dashboard_resp.json()
 
-        # Gather the original widgets (report tokens)
-        tokens = og_dashboard["widget_tokens"]
-        report_names = [w["title"] for w in og_dashboard["widgets"]]
+        # Gather the original widgets; widget_tokens is deprecated, and a
+        # dashboard can legitimately show the same report in two widgets
+        source_widgets = og_dashboard["widgets"]
+        report_names = [w["title"] for w in source_widgets]
 
         print("------")
-        print(len(tokens), "reports to create: ", ", ".join(report_names))
+        print(len(source_widgets), "reports to create: ", ", ".join(report_names))
         print("------")
 
         # Create a folder in the destination to store these new Cost/Resource Reports
@@ -127,7 +136,8 @@ def copy_dashboards(source_api_token, destination_api_token):
         successful_report_names = []
         unsuccessful_report_names = []
 
-        for token in tokens:
+        for source_widget in source_widgets:
+            token = source_widget["widgetable_token"]
             print("------")
             # Resource Report
             if token.startswith("prvdr_rsrc_rprt"):
@@ -155,7 +165,7 @@ def copy_dashboards(source_api_token, destination_api_token):
                     create_new_resource_report = create_new_resource_report_resp.json()
 
                     if create_new_resource_report_resp.status_code == 201:
-                        widget_list.append(create_new_resource_report["token"])
+                        widget_list.append(widget_payload(create_new_resource_report["token"], source_widget))
                         successful_report_names.append(create_new_resource_report["title"])
                         print("Successfully created", create_new_resource_report["title"], 
                               "in destination (", create_new_resource_report["token"], ")")
@@ -209,7 +219,7 @@ def copy_dashboards(source_api_token, destination_api_token):
                     create_new_cost_report = create_new_cost_report_resp.json()
 
                     if create_new_cost_report_resp.status_code == 201:
-                        widget_list.append(create_new_cost_report["token"])
+                        widget_list.append(widget_payload(create_new_cost_report["token"], source_widget))
                         successful_report_names.append(create_new_cost_report["title"])
                         print("Successfully created", create_new_cost_report["title"], 
                               "in destination (", create_new_cost_report["token"], ")")
@@ -252,7 +262,7 @@ def copy_dashboards(source_api_token, destination_api_token):
                     create_new_fcr = create_new_fcr_resp.json()
 
                     if create_new_fcr_resp.status_code == 201:
-                        widget_list.append(create_new_fcr["token"])
+                        widget_list.append(widget_payload(create_new_fcr["token"], source_widget))
                         successful_report_names.append(create_new_fcr["title"])
                         print("Successfully created", create_new_fcr["title"],
                               "in destination (", create_new_fcr["token"], ")")
@@ -293,7 +303,7 @@ def copy_dashboards(source_api_token, destination_api_token):
                     create_new_ker = create_new_ker_resp.json()
 
                     if create_new_ker_resp.status_code == 201:
-                        widget_list.append(create_new_ker["token"])
+                        widget_list.append(widget_payload(create_new_ker["token"], source_widget))
                         successful_report_names.append(create_new_ker["title"])
                         print("Successfully created", create_new_ker["title"],
                               "in destination (", create_new_ker["token"], ")")
@@ -314,16 +324,23 @@ def copy_dashboards(source_api_token, destination_api_token):
                     continue
                     
                 nfr = nfr_resp.json()
-                print("Copying Kubernetes Report:", nfr["title"], f"({nfr['token']})")
+                print("Copying Network Flow Report:", nfr["title"], f"({nfr['token']})")
 
                 # Build the payload for the new Network Flow Report.
                 new_nfr_payload = {
                     "title": nfr["title"],
                     "workspace_token": destination_workspace_token,
-                    "filter": nfr["filter"],
-                    "aggregated_by": nfr["aggregated_by"],
-                    "date_interval": nfr["date_interval"]
+                    "filter": nfr.get("filter"),
+                    # GET returns groupings comma-joined; POST wants an array
+                    "groupings": nfr["groupings"].split(",") if nfr.get("groupings") else None,
+                    "flow_direction": nfr.get("flow_direction"),
+                    "flow_weight": nfr.get("flow_weight"),
+                    "date_interval": nfr.get("date_interval"),
+                    # custom date intervals require both dates on create
+                    "start_date": nfr.get("start_date"),
+                    "end_date": nfr.get("end_date")
                 }
+                new_nfr_payload = {k: v for k, v in new_nfr_payload.items() if v is not None}
 
                 try:
                     create_new_nfr_resp = requests.post(
@@ -334,7 +351,7 @@ def copy_dashboards(source_api_token, destination_api_token):
                     create_new_nfr = create_new_nfr_resp.json()
 
                     if create_new_nfr_resp.status_code == 201:
-                        widget_list.append(create_new_nfr["token"])
+                        widget_list.append(widget_payload(create_new_nfr["token"], source_widget))
                         successful_report_names.append(create_new_nfr["title"])
                         print("Successfully created", create_new_nfr["title"],
                               "in destination (", create_new_nfr["token"], ")")
@@ -352,13 +369,13 @@ def copy_dashboards(source_api_token, destination_api_token):
 
         # Finally, create the new dashboard
         dashboard_payload = {
-            "widget_tokens": widget_list,
+            "widgets": widget_list,
             "title": og_dashboard["title"],
             "workspace_token": destination_workspace_token,
             "date_interval": "last_6_months"  # Or whatever default you prefer
         }
         new_dashboard_resp = requests.post(
-            f"{url}/dashboards/",
+            f"{url}/dashboards",
             json=dashboard_payload,
             headers=headers(destination_api_token)
         )

--- a/python/explore-active-resources/explore-active-resources.ipynb
+++ b/python/explore-active-resources/explore-active-resources.ipynb
@@ -91,7 +91,7 @@
     "```\n",
     "{\n",
     "  \"links\": {\n",
-    "    \"self\": \"https://api.vantage.sh/v2/resources?resource_report_token=prvdr_rsrc_rprt_a12f345345aad1ac_cost=true\",\n",
+    "    \"self\": \"https://api.vantage.sh/v2/resources?resource_report_token=prvdr_rsrc_rprt_a12f345345aad1ac&include_cost=true\",\n",
     "    \"first\": \"https://api.vantage.sh/v2/resources?resource_report_token=prvdr_rsrc_rprt_a12f345345aad1ac&include_cost=true&page=1\",\n",
     "    \"next\": \"https://api.vantage.sh/v2/resources?resource_report_token=prvdr_rsrc_rprt_a12f345345aad1ac&include_cost=true&page=2\",\n",
     "    \"last\": \"https://api.vantage.sh/v2/resources?resource_report_token=prvdr_rsrc_rprt_a12f345345aad1ac&include_cost=true&page=100\",\n",
@@ -99,7 +99,7 @@
     "  },\n",
     "```\n",
     "\n",
-    "The API also has a rate limit of 20 requests per minute. The loop below extracts all data and accounts for any [rate-limiting](https://docs.vantage.sh/api/rate_limiting) to add a delay each minute between requests."
+    "The API [rate limits](https://docs.vantage.sh/api/rate_limiting) requests and returns `x-rate-limit-*` headers on every response. The loop below extracts all data and, when the headers show the current window is exhausted, sleeps until the window resets."
    ]
   },
   {
@@ -111,7 +111,6 @@
    "source": [
     "# Create a list to collect the data across all pages\n",
     "all_data = []\n",
-    "page = 1\n",
     "\n",
     "# Loops through pagination to retrieve all pages\n",
     "while url:\n",
@@ -123,14 +122,16 @@
     "    data = response.json()\n",
     "    all_data.extend(data[\"resources\"])\n",
     "    \n",
+    "    # links.next is a full URL that already carries the query string\n",
     "    url = data[\"links\"].get(\"next\")\n",
-    "    page += 1\n",
+    "    params = None\n",
     "\n",
-    "    # Handles rate-limiting, as the API is limited to 20 requests per minute\n",
-    "    if response.headers.get(\"X-RateLimit-Remaining\") == \"0\":\n",
-    "        reset_time = int(response.headers.get(\"X-RateLimit-Reset\", 60))\n",
-    "        print(f\"Rate limit hit. Sleeping for {reset_time} seconds...\")\n",
-    "        time.sleep(reset_time)\n",
+    "    # Handles rate-limiting; x-rate-limit-reset is a Unix timestamp\n",
+    "    if response.headers.get(\"x-rate-limit-remaining\") == \"0\":\n",
+    "        reset_at = int(response.headers.get(\"x-rate-limit-reset\", 0))\n",
+    "        wait_seconds = max(reset_at - time.time(), 1)\n",
+    "        print(f\"Rate limit hit. Sleeping for {wait_seconds:.0f} seconds...\")\n",
+    "        time.sleep(wait_seconds)\n",
     "    else:\n",
     "        time.sleep(1)  "
    ]

--- a/python/terraform-cdktf/README.md
+++ b/python/terraform-cdktf/README.md
@@ -14,17 +14,14 @@ CDKTF takes the infrastructure you define and synthesizes it into JSON configura
 
 ## Complete the Demo
 
-1. Create a directory for your project and initialize a Python (or your language of choice) CDKTF project. Add the files from this repo to the directory.
+1. Create a directory for your project and initialize a Python (or your language of choice) CDKTF project with the `vantage-sh/vantage` provider. Specify the `local` flag to use local state storage. Initialize first: `cdktf init` refuses to scaffold into a non-empty directory.
 
     ```bash
     mkdir vantage-cdktf-example && cd vantage-cdktf-example 
+    cdktf init --template=python --local --providers="vantage-sh/vantage"
     ``` 
 
-2. Initialize the `vantage-sh/vantage` provider. Specify the `local` flag to use local state storage.
-
-   ```bash
-    cdktf init --template=python --local --providers="vantage-sh/vantage"
-   ```
+2. Add the files from this repo (`main.py` and `vantage_stack.py`) to the directory.
 
 3. Deploy the configuration.
    

--- a/python/terraform-cdktf/main.py
+++ b/python/terraform-cdktf/main.py
@@ -2,7 +2,7 @@ import os
 from constructs import Construct
 from cdktf import App, TerraformStack
 from imports.vantage.provider import VantageProvider
-from vantage-stack import VantageCostStack
+from vantage_stack import VantageCostStack
 
 
 class MyStack(TerraformStack):

--- a/python/terraform-cdktf/vantage_stack.py
+++ b/python/terraform-cdktf/vantage_stack.py
@@ -1,4 +1,4 @@
-# vantage-stack.py
+# vantage_stack.py
 from constructs import Construct
 from imports.vantage.cost_report import CostReport
 from imports.vantage.folder import Folder


### PR DESCRIPTION
## Summary
Four python demos fail on first run. Each fix was verified against the v2 API implementation, not just the docs:

- `aws-account-based-virtual-tag` reads `VANTAGE_ACCESS_TOKEN` while its README exports `VANTAGE_API_TOKEN`, so it sends `Bearer None` and fails auth out of the box. Also fixed: the sanitizer stripped only the literal substring `'?!` instead of each character, HTTP errors passed silently (no `raise_for_status`), and a never-used sts client
- `terraform-cdktf` cannot run at all: `vantage-stack.py` is not an importable module name and `from vantage-stack import` is a SyntaxError. Renamed to `vantage_stack.py`, fixed the import, and reordered the README so `cdktf init` runs first (it refuses a non-empty directory)
- `dashboard-replicator` crashes on every Network Flow Report clone by reading `aggregated_by`, a field that does not exist on NFRs. The clone payload now sends `filter`, `groupings` (split from the comma-joined GET form into the array POST expects), `flow_direction`, `flow_weight`, and passes `start_date`/`end_date` through so custom ranges survive. Also moved off the deprecated `widget_tokens` field on both read and write (`widgets` with `widgetable_token`, preserving each widget's `display_type`, including duplicate widgets for the same report), fixed a copy-paste print label, and the README now installs `simple-term-menu` and drops the claim that FCRs cannot be created via API (the script creates them)
- `explore-active-resources`' rate-limit guard never fired: it checks `X-RateLimit-*` but the API sends `x-rate-limit-*` (requests is case-insensitive, not hyphen-insensitive), and had it fired it would sleep for the raw Unix timestamp, about 1.7 billion seconds. It also re-appended `params` to `links.next` URLs, duplicating query args on every page. Fixed all three, plus stale rate-limit prose and a malformed sample URL in the markdown

Left out deliberately: behavior changes that need a product call, like replicator pagination beyond the first page of dashboards, dashboard lookup by title, recreating saved filters, and virtual-tag rerun dedupe. I'd rather file those as issues than widen a repair PR.

## Test plan
- [x] `py_compile` passes on every touched file; all notebook code cells compile, and the replicator runs on Python 3.9 (union annotations guarded by `from __future__ import annotations`)
- [x] The exact payloads the fixed scripts construct were replayed through the v2 API's own validation: virtual tag config, dashboards with widgets both with and without settings, and network flow reports with array groupings plus a custom date range. All accepted with 201s
- [x] `widget_payload` verified against literal cases: settings kept when present, dropped when absent or null
- [x] No leftover references: `grep -r vantage-stack` is clean, env var names match the READMEs, dependency lists match the install commands