### PR TITLE
Feat: Add LLM telemetry cold start examples for OpenAI and Anthropic.

### DIFF
--- a/python/llm-telemetry-cold-start/README.md
+++ b/python/llm-telemetry-cold-start/README.md
@@ -1,6 +1,6 @@
 # Step 0: Emit Token Cost Allocation records from OpenAI and Anthropic
 
-[Custom LLM Telemetry Enrichment](https://docs.vantage.sh/custom_telemetry) uses the **Token Cost Allocation Specification**: write one JSON record per LLM request to an S3 bucket you own, and Vantage splits the matching provider bill across the tags those records carry (team, feature, customer, and so on). The docs pick up once you already have records in that schema. This demo is Step 0 — starting from an API key, capture usage from each call and produce spec-conformant `YYYY/MM/DD/*.jsonl.gz` objects Vantage can read.
+[Custom LLM Telemetry Enrichment](https://docs.vantage.sh/custom_llm_source) uses the **Token Cost Allocation Specification**: write one JSON record per LLM request to an S3 bucket you own, and Vantage splits the matching provider bill across the tags those records carry (team, feature, customer, and so on). The docs pick up once you already have records in that schema. This demo is Step 0 — starting from an API key, capture usage from each call and produce spec-conformant `YYYY/MM/DD/*.jsonl.gz` objects Vantage can read.
 
 Three files:
 

--- a/python/llm-telemetry-cold-start/README.md
+++ b/python/llm-telemetry-cold-start/README.md
@@ -1,10 +1,10 @@
-# LLM Telemetry Cold Start: OpenAI and Anthropic to Vantage
+# Step 0: Emit Token Cost Allocation records from OpenAI and Anthropic
 
-[Custom LLM Telemetry Enrichment](https://docs.vantage.sh/custom_telemetry) splits your real OpenAI and Anthropic bills across teams, features, or customers, in proportion to per-request token records you write to an S3 bucket. This demo covers the step the docs assume: starting from nothing but an API key, capture usage from each LLM call and produce spec-conformant records Vantage can read.
+[Custom LLM Telemetry Enrichment](https://docs.vantage.sh/custom_telemetry) uses the **Token Cost Allocation Specification**: write one JSON record per LLM request to an S3 bucket you own, and Vantage splits the matching provider bill across the tags those records carry (team, feature, customer, and so on). The docs pick up once you already have records in that schema. This demo is Step 0 — starting from an API key, capture usage from each call and produce spec-conformant `YYYY/MM/DD/*.jsonl.gz` objects Vantage can read.
 
 Three files:
 
-- `emitter.py` builds records from raw API responses, validates them, and writes date-partitioned gzipped NDJSON. The mapping functions are pure and copy-paste portable.
+- `emitter.py` builds Token Cost Allocation records from raw API responses, validates them, and writes date-partitioned gzipped NDJSON. The mapping functions are pure and copy-paste portable.
 - `openai_cold_start.py` and `anthropic_cold_start.py` are complete worked examples: one API call, one record, one object.
 
 ## Prerequisites
@@ -48,11 +48,13 @@ Connect it in Vantage:
 
 1. On the [Integrations page](https://console.vantage.sh/settings/integrations), add a **Custom LLM Enrichment Source** and pick your bucket.
 2. Enter `llm` as the prefix. That is where the writer puts objects. (Different prefix? Pass `prefix=` to `TelemetryWriter` to match.)
-3. Apply the read-access grant the flow gives you (CloudFormation, CLI, or Terraform; it attaches to your existing Vantage AWS role), then click **Check Permissions**.
+3. Apply the read-only grant the flow gives you (CloudFormation, CLI, or Terraform; it attaches to your existing Vantage cross-account AWS role — no new role or credentials), then click **Check Permissions**.
 
 The Anthropic variant is identical with `pip install anthropic` and `ANTHROPIC_API_KEY`.
 
 ## What a record looks like
+
+One JSON object per request, matching the Token Cost Allocation Specification:
 
 ```json
 {
@@ -70,7 +72,15 @@ The Anthropic variant is identical with `pip install anthropic` and `ANTHROPIC_A
 }
 ```
 
-The tags are the whole point. They become cost dimensions in Vantage, so spend groups and filters by `team` or `purpose` exactly like any other tag.
+The tags are the whole point. They become cost dimensions in Vantage, so you can group, filter, budget, and alert by `team` or `purpose` like any other tag.
+
+**`resource_account_id`.** Recommended whenever one bucket carries logs for multiple integrations of the same provider, so each request matches the right costs (for example an OpenAI project or org id). Records are plain dicts — set it before `writer.add()`:
+
+```python
+record["resource_account_id"] = "proj_abc123"
+```
+
+See the schema section in the [Custom Telemetry docs](https://docs.vantage.sh/custom_telemetry) for the full field list.
 
 ## The mapping, and the one trap
 
@@ -189,8 +199,8 @@ Run the checks yourself: `python3 test_emitter.py` (stdlib only).
 - **Failure semantics, stated honestly.** The buffer is in memory; a crash loses whatever was not yet flushed. That is usually acceptable here, because lost telemetry degrades allocation precision, never billing accuracy: uncovered spend lands in the untagged leftover row and totals still reconcile. If you need better, spool records to local disk first. `flush()` is safe to retry: a partial failure keeps the buffer, and re-written days deduplicate by `event_id`.
 - **Retries are already safe.** Re-sending the same records is harmless: Vantage keeps one record per `event_id` per day.
 - **Timestamps.** The writer partitions by the record timestamp's UTC date. The timestamp is when you received the response; if you backfill from stored responses, convert the response's own `created` time (OpenAI) or your logged receipt time instead of `now()`.
-- **Tags hygiene.** Keep request ids, user emails, and conversation ids out of `tags`; they are high-cardinality and some are PII. Never put API keys or secrets in any field.
-- **Other top-level fields.** Records are plain dicts. Assign before `writer.add()`, for example `record["resource_account_id"] = "org-..."` when one bucket serves multiple accounts of the same provider.
+- **Tags hygiene.** Prefer stable, low-cardinality keys (`team`, `environment`, `purpose`). Keep request ids, user emails, and conversation ids out of `tags`; they are high-cardinality and some are PII. Tags are case-sensitive (`team` ≠ `Team`). Never put API keys or secrets in any field.
+- **`resource_account_id`.** Set it when one bucket serves multiple accounts of the same provider so each request joins the right bill (see the callout under [What a record looks like](#what-a-record-looks-like)). Other optional top-level fields (`provider_region`, `api_key_id`, `is_batch`, …) work the same way: assign on the dict before `writer.add()`.
 
 ## Other providers and languages
 

--- a/python/llm-telemetry-cold-start/README.md
+++ b/python/llm-telemetry-cold-start/README.md
@@ -1,0 +1,197 @@
+# LLM Telemetry Cold Start: OpenAI and Anthropic to Vantage
+
+[Custom LLM Telemetry Enrichment](https://docs.vantage.sh/custom_telemetry) splits your real OpenAI and Anthropic bills across teams, features, or customers, in proportion to per-request token records you write to an S3 bucket. This demo covers the step the docs assume: starting from nothing but an API key, capture usage from each LLM call and produce spec-conformant records Vantage can read.
+
+Three files:
+
+- `emitter.py` builds records from raw API responses, validates them, and writes date-partitioned gzipped NDJSON. The mapping functions are pure and copy-paste portable.
+- `openai_cold_start.py` and `anthropic_cold_start.py` are complete worked examples: one API call, one record, one object.
+
+## Prerequisites
+
+- A Vantage account with your OpenAI and/or Anthropic cost integration connected. Enrichment splits the real bill; no bill connected, nothing to split.
+- Python 3.9+.
+- For the real-bucket step only: an S3 bucket you own, AWS credentials with `s3:PutObject` on it, and `pip install boto3`.
+
+## Quick start
+
+Dry run first. Without a bucket configured, records land in `./out` so you can see exactly what Vantage would receive:
+
+```bash
+pip install openai
+export OPENAI_API_KEY=sk-proj-...
+python3 openai_cold_start.py
+```
+
+```bash
+gunzip -c out/llm/*/*/*/*.jsonl.gz
+```
+
+You should see one JSON line per request. These two lines are genuine output from running both scripts (response ids truncated):
+
+```json
+{"event_id": "chatcmpl-EC870XwPBvp9wTb...", "timestamp": "2026-08-12T18:37:06.904876Z", "provider": "openai", "model": "gpt-4o-2024-08-06", "usage": {"input_tokens": 13, "output_tokens": 7}, "service_tier": "priority", "tags": {"team": "growth", "purpose": "cold-start-demo"}}
+{"event_id": "msg_011CdyLe2wDgAWvjmX...", "timestamp": "2026-08-12T18:37:19.505301Z", "provider": "anthropic", "model": "claude-sonnet-4-6", "usage": {"input_tokens": 13, "output_tokens": 11}, "tags": {"team": "growth", "purpose": "cold-start-demo"}}
+```
+
+Worth noticing: the model is the provider's resolved id (`gpt-4o` resolved to a dated snapshot), and the OpenAI record picked up `service_tier` straight off the live response. Both matter later, because Vantage joins records to your bill by model, and OpenAI costs are tier-priced.
+
+Then write to a real bucket:
+
+```bash
+pip install boto3
+export VANTAGE_TELEMETRY_BUCKET=my-llm-telemetry-bucket
+python3 openai_cold_start.py
+```
+
+Connect it in Vantage:
+
+1. On the [Integrations page](https://console.vantage.sh/settings/integrations), add a **Custom LLM Enrichment Source** and pick your bucket.
+2. Enter `llm` as the prefix. That is where the writer puts objects. (Different prefix? Pass `prefix=` to `TelemetryWriter` to match.)
+3. Apply the read-access grant the flow gives you (CloudFormation, CLI, or Terraform; it attaches to your existing Vantage AWS role), then click **Check Permissions**.
+
+The Anthropic variant is identical with `pip install anthropic` and `ANTHROPIC_API_KEY`.
+
+## What a record looks like
+
+```json
+{
+  "event_id": "chatcmpl-AbC123",
+  "timestamp": "2026-08-12T12:30:45.123456Z",
+  "provider": "openai",
+  "model": "gpt-4o-2024-08-06",
+  "service_tier": "default",
+  "usage": {
+    "input_tokens": 2129,
+    "output_tokens": 112,
+    "cache_read_input_tokens": 572
+  },
+  "tags": {"team": "growth", "purpose": "cold-start-demo"}
+}
+```
+
+The tags are the whole point. They become cost dimensions in Vantage, so spend groups and filters by `team` or `purpose` exactly like any other tag.
+
+## The mapping, and the one trap
+
+OpenAI maps straight through. `usage.prompt_tokens` already includes cached tokens, which is the inclusive total the spec expects; `prompt_tokens_details.cached_tokens` becomes `cache_read_input_tokens`, and `response.id` is a ready-made `event_id`.
+
+Anthropic has the trap. Its `usage.input_tokens` EXCLUDES cached tokens, so the spec total must be reassembled:
+
+```
+spec input_tokens = input_tokens + cache_read_input_tokens + cache_creation_input_tokens
+```
+
+Send Anthropic's raw `input_tokens` and the cache-priced portion of your spend is misallocated. `record_from_anthropic` does the addition; `test_emitter.py` pins it.
+
+## What you'll see in Vantage
+
+Enrichment runs with your provider's regular cost refresh. Expect your tag keys in Cost Report filters within about a day of connecting, not minutes. Late records are fine: recent days are reprocessed on a rolling three-day window.
+
+A single demo record will render as a near-invisible sliver next to the untagged remainder of that day's real spend. That is expected; coverage grows as you instrument real traffic. Costs with no matching telemetry pass through unchanged, and partially covered days show an untagged leftover row, so totals always reconcile against the bill.
+
+If splits are missing after a refresh cycle, the usual causes are skipped records (see the validation table below), a prefix mismatch between the writer and the source configuration, or a missing provider cost integration. The [troubleshooting docs](https://docs.vantage.sh/custom_telemetry) cover the rest.
+
+---
+
+# Going further
+
+Everything below is for taking the demo into a real codebase.
+
+## Streaming calls
+
+Production apps stream, and streamed responses deliver usage differently. The mapping functions need no changes; the work is getting a complete usage object out of the stream.
+
+OpenAI only sends usage if you ask, on a final extra chunk whose `choices` list is empty:
+
+```python
+stream = client.chat.completions.create(
+    model="gpt-4o",
+    messages=messages,
+    stream=True,
+    stream_options={"include_usage": True},  # required, or usage never arrives
+)
+final_usage = None
+for chunk in stream:
+    event_id, model = chunk.id, chunk.model   # identical on every chunk
+    # ...render chunk.choices deltas...
+    if chunk.usage is not None:               # only the final chunk carries usage
+        final_usage = chunk.usage
+
+if final_usage is not None:                   # aborted streams have no usage: skip
+    record = record_from_openai(
+        {"id": event_id, "model": model, "usage": final_usage.model_dump()},
+        timestamp=utc_now_iso(),
+        tags={"team": "growth"},
+    )
+```
+
+Note: the SDK's `client.chat.completions.stream()` helper does NOT set `include_usage` for you. Pass `stream_options` there too, then use `stream.get_final_completion().model_dump()`. On the Responses API, the `response.completed` event carries the full response, so `record_from_openai(event.response.model_dump(), ...)` works as-is.
+
+Anthropic's SDK does the merge for you:
+
+```python
+with client.messages.stream(model="claude-sonnet-4-6", max_tokens=1024,
+                            messages=messages) as stream:
+    for text in stream.text_stream:
+        ...  # render incrementally
+    message = stream.get_final_message()
+
+record = record_from_anthropic(message.model_dump(), timestamp=utc_now_iso(),
+                               tags={"team": "growth"})
+```
+
+One rule for both providers: do not emit a record from an aborted stream. OpenAI never delivers usage for it, and Anthropic's snapshot would carry a 1-to-3-token partial output count that skews the proportional split.
+
+## Where this goes in a real codebase
+
+Nobody adds three lines after every call site. Pick the single choke point your LLM traffic already flows through and record there: a shared completion helper or client factory if you have one, otherwise a thin wrapper around the SDK call:
+
+```python
+def recorded(create: Callable, writer: TelemetryWriter,
+             tags: dict | None = None) -> Callable:
+    """Wrap an SDK create call so every completion emits a telemetry record."""
+    def wrapped(*args: object, **kwargs: object) -> object:
+        response = create(*args, **kwargs)
+        try:
+            writer.add(record_from_openai(response.model_dump(), utc_now_iso(), tags))
+        except Exception:
+            log.warning("telemetry record dropped", exc_info=True)
+        return response
+    return wrapped
+
+chat = recorded(client.chat.completions.create, writer, {"team": "growth"})
+```
+
+The `try/except` is not optional decoration: telemetry must never break the serving path. An odd provider response should cost you one record, not a 500.
+
+Async works the same way. `AsyncOpenAI` and `AsyncAnthropic` return the same response types, so the pure mapping functions are shared unchanged. Keep the S3 flush off the event loop (`asyncio.to_thread(writer.flush)` or a background thread), and flush on shutdown via your framework's lifespan hook or `atexit`.
+
+## Validation before you connect
+
+`validate_record` returns every reason Vantage would skip a record, so a bad pipeline fails in your terminal instead of silently in ingestion. The rules:
+
+| Record property | Verdict |
+|---|---|
+| `event_id`, `timestamp`, `provider`, `model`, `usage` present and non-empty | required, or the record is skipped |
+| `timestamp` as ISO 8601 UTC with an explicit `Z` | epoch numbers are rejected |
+| `provider` one of `openai`, `anthropic`, `aws`/`bedrock`, `gcp`/`gemini`/`google`/`vertex`, `azure`/`azure_openai` | anything else is skipped |
+| usage counts as JSON integers | string counts like `"2129"` are dropped by ingestion |
+| at least one usage field a positive integer | all-zero usage is skipped |
+| `status` absent or `success` | any other value skips the record |
+| `uncached_input_tokens` omitted | Vantage derives it; a malformed explicit value silently drops the input row |
+
+Run the checks yourself: `python3 test_emitter.py` (stdlib only).
+
+## Production notes
+
+- **Batching.** One object per request is the anti-pattern; buffer and flush on thresholds. Reasonable defaults: ~1,000 records or ~60 seconds, whichever comes first, and always at shutdown. Multiple web workers each holding their own writer is fine: object names are uuid-suffixed so keys never collide, and Vantage dedups per `event_id` per day.
+- **Failure semantics, stated honestly.** The buffer is in memory; a crash loses whatever was not yet flushed. That is usually acceptable here, because lost telemetry degrades allocation precision, never billing accuracy: uncovered spend lands in the untagged leftover row and totals still reconcile. If you need better, spool records to local disk first. `flush()` is safe to retry: a partial failure keeps the buffer, and re-written days deduplicate by `event_id`.
+- **Retries are already safe.** Re-sending the same records is harmless: Vantage keeps one record per `event_id` per day.
+- **Timestamps.** The writer partitions by the record timestamp's UTC date. The timestamp is when you received the response; if you backfill from stored responses, convert the response's own `created` time (OpenAI) or your logged receipt time instead of `now()`.
+- **Tags hygiene.** Keep request ids, user emails, and conversation ids out of `tags`; they are high-cardinality and some are PII. Never put API keys or secrets in any field.
+- **Other top-level fields.** Records are plain dicts. Assign before `writer.add()`, for example `record["resource_account_id"] = "org-..."` when one bucket serves multiple accounts of the same provider.
+
+## Other providers and languages
+
+This demo maps the direct OpenAI and Anthropic APIs, in Python. Azure OpenAI responses are shape-compatible with `record_from_openai`; set `provider` to `azure_openai` so records match the billed integration. Bedrock and Vertex use different response field names and are not mapped here. The record example, the validation table, and the Anthropic formula are the language-neutral spec: porting the two mapping functions to another provider or language (TypeScript, Go) is a ~30-line exercise against that table.

--- a/python/llm-telemetry-cold-start/anthropic_cold_start.py
+++ b/python/llm-telemetry-cold-start/anthropic_cold_start.py
@@ -1,0 +1,35 @@
+"""One Anthropic call, one Vantage token allocation record, shipped.
+
+Requires ANTHROPIC_API_KEY. Set VANTAGE_TELEMETRY_BUCKET to write to S3;
+without it, records land in ./out for inspection.
+"""
+from __future__ import annotations
+
+import os
+
+from anthropic import Anthropic
+
+from emitter import TelemetryWriter, record_from_anthropic, utc_now_iso
+
+
+def main() -> None:
+    """Call Anthropic once and write the resulting record as spec .jsonl.gz."""
+    response = Anthropic().messages.create(
+        model="claude-sonnet-4-6",
+        max_tokens=64,
+        messages=[{"role": "user", "content": "Say hello in five words."}],
+    )
+    record = record_from_anthropic(
+        response.model_dump(),
+        timestamp=utc_now_iso(),
+        tags={"team": "growth", "purpose": "cold-start-demo"},
+    )
+
+    bucket = os.environ.get("VANTAGE_TELEMETRY_BUCKET")
+    writer = TelemetryWriter(bucket, dry_run_dir=None if bucket else "out")
+    writer.add(record)
+    print("wrote:", *writer.flush())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/llm-telemetry-cold-start/emitter.py
+++ b/python/llm-telemetry-cold-start/emitter.py
@@ -1,0 +1,213 @@
+"""Build and ship Vantage Token Cost Allocation records from LLM API responses.
+
+Everything above TelemetryWriter is pure (response data in, record out) and
+testable with plain dicts; TelemetryWriter is the shell that buffers records
+and writes date-partitioned .jsonl.gz objects to S3 or a local directory.
+Spec: https://docs.vantage.sh/custom_telemetry
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+ACCEPTED_PROVIDERS = {
+    "openai", "anthropic", "aws", "bedrock",
+    "gcp", "gemini", "google", "vertex",
+    "azure", "azure_openai", "azure-openai",
+}
+
+USAGE_FIELDS = (
+    "input_tokens",
+    "uncached_input_tokens",
+    "output_tokens",
+    "cache_read_input_tokens",
+    "cache_write_input_tokens",
+)
+
+
+# --- core: pure functions, data in, data out ---------------------------------
+
+def record_from_openai(response: dict, timestamp: str, tags: dict | None = None) -> dict:
+    """Return a spec record from an OpenAI response dict (chat completions or responses API)."""
+    usage = response.get("usage") or {}
+    details = usage.get("prompt_tokens_details") or usage.get("input_tokens_details") or {}
+    record = {
+        "event_id": response["id"],
+        "timestamp": timestamp,
+        "provider": "openai",
+        "model": response["model"],
+        # OpenAI's prompt/input token count already includes cached tokens,
+        # which is exactly the inclusive semantics the spec expects.
+        "usage": positive_usage({
+            "input_tokens": usage.get("prompt_tokens") or usage.get("input_tokens"),
+            "output_tokens": usage.get("completion_tokens") or usage.get("output_tokens"),
+            "cache_read_input_tokens": details.get("cached_tokens"),
+        }),
+    }
+    if response.get("service_tier"):
+        record["service_tier"] = response["service_tier"]
+    if tags:
+        record["tags"] = tags
+    return record
+
+
+def record_from_anthropic(response: dict, timestamp: str, tags: dict | None = None) -> dict:
+    """Return a spec record from an Anthropic Messages API response dict."""
+    usage = response.get("usage") or {}
+    cache_read = usage.get("cache_read_input_tokens") or 0
+    cache_write = usage.get("cache_creation_input_tokens") or 0
+    record = {
+        "event_id": response["id"],
+        "timestamp": timestamp,
+        "provider": "anthropic",
+        "model": response["model"],
+        # Anthropic's input_tokens EXCLUDES cached tokens; the spec's
+        # input_tokens is the inclusive total, so add the cache counts back.
+        # Sending Anthropic's raw value would misallocate the cache-priced
+        # portion of spend.
+        "usage": positive_usage({
+            "input_tokens": (usage.get("input_tokens") or 0) + cache_read + cache_write,
+            "output_tokens": usage.get("output_tokens"),
+            "cache_read_input_tokens": cache_read,
+            "cache_write_input_tokens": cache_write,
+        }),
+    }
+    if tags:
+        record["tags"] = tags
+    return record
+
+
+def positive_usage(entries: dict) -> dict:
+    """Return only the usage entries that are positive integers."""
+    return {
+        k: v for k, v in entries.items()
+        if isinstance(v, int) and not isinstance(v, bool) and v > 0
+    }
+
+
+def validate_record(record: dict) -> list[str]:
+    """Return the reasons Vantage would skip this record; empty means ingestible."""
+    problems = []
+    problems += [
+        f"{field} is missing or blank"
+        for field in ("event_id", "timestamp", "provider", "model")
+        if not str(record.get(field, "")).strip()
+    ]
+    if not parses_as_utc_timestamp(str(record.get("timestamp", ""))):
+        problems.append("timestamp is not ISO 8601 UTC with a Z suffix")
+    if str(record.get("provider", "")).strip().lower() not in ACCEPTED_PROVIDERS:
+        problems.append(f"provider {record.get('provider')!r} is not an accepted value")
+    status = record.get("status")
+    if status is not None and str(status).strip().lower() not in ("", "success"):
+        problems.append(f"status {status!r} is not 'success'; the record will be skipped")
+    problems += usage_problems(record.get("usage"))
+    return problems
+
+
+def usage_problems(usage: object) -> list[str]:
+    """Return every way the usage block would fail ingestion."""
+    if not isinstance(usage, dict):
+        return ["usage is not a JSON object"]
+    strings = [k for k in USAGE_FIELDS if isinstance(usage.get(k), str)]
+    problems = [
+        f"usage.{k} is a string; counts must be JSON integers or they are dropped"
+        for k in strings
+    ]
+    if not positive_usage({k: usage.get(k) for k in USAGE_FIELDS}):
+        problems.append("no usage field is a positive integer")
+    return problems
+
+
+def parses_as_utc_timestamp(value: str) -> bool:
+    """Return True when value is ISO 8601 with an explicit Z suffix."""
+    if not value.endswith("Z"):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return True
+    except ValueError:
+        return False
+
+
+def records_by_day(records: list[dict]) -> dict:
+    """Return records grouped by the UTC date of their timestamp."""
+    days: dict = {}
+    for record in records:
+        days.setdefault(record["timestamp"][:10], []).append(record)
+    return days
+
+
+def object_key(day: str, batch_id: str, prefix: str) -> str:
+    """Return the date-partitioned key Vantage's reader expects for a YYYY-MM-DD day."""
+    return f"{prefix}/{day.replace('-', '/')}/{batch_id}.jsonl.gz"
+
+
+def ndjson_gz(records: list[dict]) -> bytes:
+    """Return the records gzip-compressed, one JSON object per line, no outer array."""
+    lines = "".join(json.dumps(record) + "\n" for record in records)
+    return gzip.compress(lines.encode("utf-8"))
+
+
+# --- shell: clock, buffering, S3 ---------------------------------------------
+
+def utc_now_iso() -> str:
+    """Return the current UTC time in the spec's ISO 8601 Z format."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+class TelemetryWriter:
+    """Buffers records and writes them as date-partitioned .jsonl.gz objects.
+
+    Thread-safe: add() and flush() may be called from multiple threads (for
+    example FastAPI's threadpool plus a background flusher). flush() is safe
+    to retry after a failure: the batch goes back into the buffer, and a
+    retry that re-writes an already-written day is harmless because Vantage
+    keeps one record per event_id per day.
+    """
+
+    def __init__(self, bucket: str | None, prefix: str = "llm",
+                 dry_run_dir: str | None = None) -> None:
+        """Write to the S3 bucket when set, else to dry_run_dir for inspection."""
+        self._bucket = bucket
+        self._prefix = prefix
+        self._dry_run_dir = dry_run_dir
+        self._lock = threading.Lock()
+        self._records: list[dict] = []
+
+    def add(self, record: dict) -> None:
+        """Buffer one record, raising ValueError on anything Vantage would skip."""
+        problems = validate_record(record)
+        if problems:
+            raise ValueError("record would be skipped: " + "; ".join(problems))
+        with self._lock:
+            self._records.append(record)
+
+    def flush(self) -> list[str]:
+        """Write one object per UTC day and return the keys written."""
+        with self._lock:
+            batch, self._records = self._records, []
+        keys = []
+        try:
+            for day, records in records_by_day(batch).items():
+                key = object_key(day, uuid4().hex, self._prefix)
+                self._write(key, ndjson_gz(records))
+                keys.append(key)
+        except Exception:
+            with self._lock:
+                self._records[:0] = batch
+            raise
+        return keys
+
+    def _write(self, key: str, body: bytes) -> None:
+        """Put one object to S3 or the local dry-run directory."""
+        if self._dry_run_dir is not None:
+            path = Path(self._dry_run_dir) / key
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(body)
+            return
+        import boto3
+        boto3.client("s3").put_object(Bucket=self._bucket, Key=key, Body=body)

--- a/python/llm-telemetry-cold-start/openai_cold_start.py
+++ b/python/llm-telemetry-cold-start/openai_cold_start.py
@@ -1,0 +1,34 @@
+"""One OpenAI call, one Vantage token allocation record, shipped.
+
+Requires OPENAI_API_KEY. Set VANTAGE_TELEMETRY_BUCKET to write to S3;
+without it, records land in ./out for inspection.
+"""
+from __future__ import annotations
+
+import os
+
+from openai import OpenAI
+
+from emitter import TelemetryWriter, record_from_openai, utc_now_iso
+
+
+def main() -> None:
+    """Call OpenAI once and write the resulting record as spec .jsonl.gz."""
+    response = OpenAI().chat.completions.create(
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "Say hello in five words."}],
+    )
+    record = record_from_openai(
+        response.model_dump(),
+        timestamp=utc_now_iso(),
+        tags={"team": "growth", "purpose": "cold-start-demo"},
+    )
+
+    bucket = os.environ.get("VANTAGE_TELEMETRY_BUCKET")
+    writer = TelemetryWriter(bucket, dry_run_dir=None if bucket else "out")
+    writer.add(record)
+    print("wrote:", *writer.flush())
+
+
+if __name__ == "__main__":
+    main()

--- a/python/llm-telemetry-cold-start/test_emitter.py
+++ b/python/llm-telemetry-cold-start/test_emitter.py
@@ -1,0 +1,190 @@
+"""Tests for emitter's pure core, runnable with the stdlib alone: python3 test_emitter.py.
+
+The fixtures are trimmed real response shapes; every assertion mirrors a rule
+from the Vantage spec (see the skip-rule table in README.md).
+"""
+from __future__ import annotations
+
+import gzip
+import json
+import re
+
+from emitter import (
+    TelemetryWriter,
+    ndjson_gz,
+    object_key,
+    record_from_anthropic,
+    record_from_openai,
+    records_by_day,
+    validate_record,
+)
+
+TS = "2026-08-12T12:30:45.123456Z"
+
+OPENAI_CHAT = {
+    "id": "chatcmpl-AbC123",
+    "model": "gpt-4o-2024-08-06",
+    "service_tier": "default",
+    "usage": {
+        "prompt_tokens": 2129,
+        "completion_tokens": 112,
+        "total_tokens": 2241,
+        "prompt_tokens_details": {"cached_tokens": 572},
+    },
+}
+
+OPENAI_RESPONSES_API = {
+    "id": "resp_XyZ789",
+    "model": "gpt-4o-2024-08-06",
+    "usage": {
+        "input_tokens": 900,
+        "output_tokens": 40,
+        "input_tokens_details": {"cached_tokens": 100},
+    },
+}
+
+ANTHROPIC_MSG = {
+    "id": "msg_01AbCd",
+    "model": "claude-sonnet-4-6",
+    "usage": {
+        "input_tokens": 1268,
+        "output_tokens": 312,
+        "cache_read_input_tokens": 572,
+        "cache_creation_input_tokens": 0,
+    },
+}
+
+
+def test_openai_chat_completion_maps() -> None:
+    """OpenAI chat usage maps straight through; prompt tokens already include cache."""
+    record = record_from_openai(OPENAI_CHAT, TS, tags={"team": "growth"})
+    assert record["event_id"] == "chatcmpl-AbC123"
+    assert record["provider"] == "openai"
+    assert record["service_tier"] == "default"
+    assert record["usage"] == {
+        "input_tokens": 2129,
+        "output_tokens": 112,
+        "cache_read_input_tokens": 572,
+    }
+    assert validate_record(record) == []
+
+
+def test_openai_responses_api_maps() -> None:
+    """The Responses API field names coalesce to the same record shape."""
+    record = record_from_openai(OPENAI_RESPONSES_API, TS)
+    assert record["usage"] == {
+        "input_tokens": 900,
+        "output_tokens": 40,
+        "cache_read_input_tokens": 100,
+    }
+    assert validate_record(record) == []
+
+
+def test_anthropic_cache_tokens_are_added_back() -> None:
+    """Anthropic input_tokens excludes cache; the spec total must include it."""
+    record = record_from_anthropic(ANTHROPIC_MSG, TS)
+    assert record["usage"]["input_tokens"] == 1268 + 572
+    assert record["usage"]["cache_read_input_tokens"] == 572
+    assert "cache_write_input_tokens" not in record["usage"]
+    assert validate_record(record) == []
+
+
+def test_validate_catches_the_spec_skip_rules() -> None:
+    """Each spec skip rule produces a named problem."""
+    assert validate_record({}) != []
+    good = record_from_openai(OPENAI_CHAT, TS)
+
+    bad_provider = dict(good, provider="cohere")
+    assert any("provider" in p for p in validate_record(bad_provider))
+
+    bad_status = dict(good, status="error")
+    assert any("status" in p for p in validate_record(bad_status))
+
+    bad_timestamp = dict(good, timestamp="1754870400")
+    assert any("timestamp" in p for p in validate_record(bad_timestamp))
+
+    string_counts = dict(good, usage={"input_tokens": "2129"})
+    assert any("JSON integers" in p for p in validate_record(string_counts))
+
+    zero_usage = dict(good, usage={"input_tokens": 0, "output_tokens": 0})
+    assert any("positive integer" in p for p in validate_record(zero_usage))
+
+
+def test_object_key_matches_vantage_layout() -> None:
+    """Keys must be <prefix>/YYYY/MM/DD/<flat-name>.jsonl.gz."""
+    key = object_key("2026-08-12", "abc123", "llm")
+    assert key == "llm/2026/08/12/abc123.jsonl.gz"
+    assert re.fullmatch(r"(.*/)?\d{4}/\d{2}/\d{2}/[^/]+\.jsonl\.gz", key)
+
+
+def test_ndjson_round_trips() -> None:
+    """Output is gzip NDJSON: one JSON object per line, no outer array."""
+    record = record_from_openai(OPENAI_CHAT, TS)
+    lines = gzip.decompress(ndjson_gz([record, record])).decode().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event_id"] == "chatcmpl-AbC123"
+
+
+def test_records_group_by_utc_day() -> None:
+    """Partitioning follows the record timestamp's UTC date."""
+    a = record_from_openai(OPENAI_CHAT, "2026-08-12T23:59:58.000000Z")
+    b = record_from_openai(OPENAI_CHAT, "2026-08-13T00:00:02.000000Z")
+    assert sorted(records_by_day([a, b])) == ["2026-08-12", "2026-08-13"]
+
+
+def test_openai_streaming_final_chunk_shape_maps() -> None:
+    """A record can be built from a stream's final usage chunk (id + model + usage)."""
+    final_chunk_shape = {
+        "id": "chatcmpl-Stream1",
+        "model": "gpt-4o-2024-08-06",
+        "usage": {
+            "prompt_tokens": 50,
+            "completion_tokens": 9,
+            "prompt_tokens_details": {"cached_tokens": 0},
+        },
+    }
+    record = record_from_openai(final_chunk_shape, TS)
+    assert record["usage"] == {"input_tokens": 50, "output_tokens": 9}
+    assert validate_record(record) == []
+
+
+class _FlakyWriter(TelemetryWriter):
+    """Writer whose first write attempt fails, for retry-semantics tests."""
+
+    def __init__(self) -> None:
+        """Start in failing mode with no destination."""
+        super().__init__(bucket=None, dry_run_dir=None)
+        self.fail = True
+        self.written: list[str] = []
+
+    def _write(self, key: str, body: bytes) -> None:
+        """Record the key, or raise while in failing mode."""
+        if self.fail:
+            raise OSError("simulated S3 outage")
+        self.written.append(key)
+
+
+def test_flush_retains_buffer_on_failure_and_retries_cleanly() -> None:
+    """A failed flush keeps every record; the retry writes them all."""
+    writer = _FlakyWriter()
+    writer.add(record_from_openai(OPENAI_CHAT, TS))
+    writer.add(record_from_anthropic(ANTHROPIC_MSG, TS))
+
+    try:
+        writer.flush()
+        raise AssertionError("flush should have raised")
+    except OSError:
+        pass
+
+    writer.fail = False
+    keys = writer.flush()
+    assert len(keys) == 1 and len(writer.written) == 1
+    assert writer.flush() == []
+
+
+if __name__ == "__main__":
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    for test in tests:
+        test()
+        print(f"ok   {test.__name__}")
+    print(f"PASS {len(tests)} tests")


### PR DESCRIPTION
## Summary

* The [custom_telemetry](https://docs.vantage.sh/custom_telemetry) docs start from records already in the common schema; there's no example of producing them. This adds the step before: `python/llm-telemetry-cold-start/`, from an API key to spec-conformant `YYYY/MM/DD/*.jsonl.gz` for OpenAI and Anthropic.
* A validating emitter (pure mapping functions, thread-safe buffered S3 writer) plus one worked script per provider. `validate_record` mirrors the spec's skip rules, so a bad pipeline fails in the terminal instead of silently in ingestion.
* The two traps that would misallocate spend are handled and tested: Anthropic's `input_tokens` excludes cached tokens and gets reassembled into the inclusive total, and usage counts must be JSON integers.
* Scope: Python, direct APIs only. Bedrock/Vertex mapping is deliberately out; the README's tables are the language-neutral spec for porting.

## Test plan
* `python3 test_emitter.py`: 9 stdlib-only tests pass.
 * Both scripts ran live against real OpenAI and Anthropic keys; the README's sample output is genuine (response ids truncated).
* Output verified against core's ingestion parser (`Cur::AIGateway::CommonSchema::LogRecordParser`, docker test env): every record parses with zero skips, models join, tags land in `request_tags`.